### PR TITLE
Fix: Add CanActivate Auth Guard in Routing

### DIFF
--- a/src/app/Services/auth.service.ts
+++ b/src/app/Services/auth.service.ts
@@ -1,28 +1,48 @@
 import { Injectable, inject } from "@angular/core";
 import { UserService } from "./user.service";
+import { User } from "../Models/user";
 
 @Injectable({
     providedIn: 'root'
 })
-export class AuthService{
-    isLogged: Boolean = false;
+export class AuthService {
+    isLoggedIn: boolean = false;
     userService: UserService = inject(UserService);
 
-    login(username: string, password: string){
-        let user = this.userService.users.find((u) => u.username === username 
-                                                    && u.password === password);
-        if(user === undefined)
-            this.isLogged = false;
-        else
-            this.isLogged = true;
+
+    login(userName: string, password: string): User {
+        const user = this.userService.users.find(user => user.username === userName && user.password === password);
+        this.isLoggedIn = user ? true : false;
         return user;
     }
-
-    logout(){
-        this.isLogged = false;
+    logout(): void {
+        this.isLoggedIn = false;
     }
-
-    IsAuthenticated(){
-        return this.isLogged;
+    authenticated() {
+        return this.isLoggedIn;
     }
 }
+
+
+// export class AuthService{
+//     isLogged: Boolean = false;
+//     userService: UserService = inject(UserService);
+
+//     login(username: string, password: string){
+//         let user = this.userService.users.find((u) => u.username === username 
+//                                                     && u.password === password);
+//         if(user === undefined)
+//             this.isLogged = false;
+//         else
+//             this.isLogged = true;
+//         return user;
+//     }
+
+//     logout(){
+//         this.isLogged = false;
+//     }
+
+//     IsAuthenticated(){
+//         return this.isLogged;
+//     }
+// }

--- a/src/app/Services/authguard.service.ts
+++ b/src/app/Services/authguard.service.ts
@@ -6,42 +6,55 @@ import { ContactComponent } from '../contact/contact.component';
 import { Course } from '../Models/course';
 import { CourseService } from './course.service';
 
-export interface IDeactivateComponent{
-    canExit: () => boolean | Observable<boolean> | Promise<boolean>;
-}
+// export interface IDeactivateComponent{
+//     canExit: () => boolean | Observable<boolean> | Promise<boolean>;
+// }
 
 
 @Injectable({
     providedIn: 'root'
 })
-export class AuthGuardService implements CanActivate, CanActivateChild, CanDeactivate<IDeactivateComponent>, Resolve<Course[]>{
+export class AuthGuardService implements CanActivate {
     authService: AuthService = inject(AuthService);
     router: Router = inject(Router);
-    courseService: CourseService = inject(CourseService);
-
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-        boolean | Observable<boolean> | Promise<boolean>
-    {
-        if(this.authService.IsAuthenticated()){
-            return true;
-        }else{
+    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Observable<boolean> | Promise<boolean>{
+        // return false;
+        const isLoggedIn = this.authService.authenticated();
+        if(isLoggedIn) return true;// this will activate the child route
+        else{
             this.router.navigate(['/Login']);
             return false;
         }
     }
-
-
-    canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> {
-        return this.canActivate(childRoute, state);
-    }
-
-    canDeactivate(component: IDeactivateComponent, currentRoute: ActivatedRouteSnapshot, 
-        currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) 
-    {
-        return component.canExit();
-    }
-
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Course[] | Observable<Course[]> | Promise<Course[]> {
-        return this.courseService.getAllcourses();
-    }
 }
+// export class AuthGuardService implements CanActivate, CanActivateChild, CanDeactivate<IDeactivateComponent>, Resolve<Course[]>{
+//     authService: AuthService = inject(AuthService);
+//     router: Router = inject(Router);
+//     courseService: CourseService = inject(CourseService);
+
+//     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
+//         boolean | Observable<boolean> | Promise<boolean>
+//     {
+//         if(this.authService.IsAuthenticated()){
+//             return true;
+//         }else{
+//             this.router.navigate(['/Login']);
+//             return false;
+//         }
+//     }
+
+
+//     canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> {
+//         return this.canActivate(childRoute, state);
+//     }
+
+//     canDeactivate(component: IDeactivateComponent, currentRoute: ActivatedRouteSnapshot, 
+//         currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) 
+//     {
+//         return component.canExit();
+//     }
+
+//     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Course[] | Observable<Course[]> | Promise<Course[]> {
+//         return this.courseService.getAllcourses();
+//     }
+// }

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -3,23 +3,24 @@ import { AuthService } from "./Services/auth.service";
 import { Router } from "@angular/router";
 import { CourseService } from "./Services/course.service";
 
-export const CanActivate = () => {
-    const authService = inject(AuthService);
-    const router = inject(Router);
+// export const CanActivate = () => {
+//     const authService = inject(AuthService);
+//     const router = inject(Router);
 
-    if(authService.IsAuthenticated()){
-        return true;
-    }else{
-        router.navigate(['/Login']);
-        return false;
-    }
-}
+//     if(authService.IsAuthenticated()){
+//         return true;
+//     }
+//     else{
+//         router.navigate(['/Login']);
+//         return false;
+//     }
+// }
 
-export const CanActivateChild = () => {
-    return CanActivate();
-}
+// export const CanActivateChild = () => {
+//     return CanActivate();
+// }
 
-export const resolve = () =>{
-    const courseService = inject(CourseService);
-    return courseService.getAllcourses();
-}
+// export const resolve = () =>{
+//     const courseService = inject(CourseService);
+//     return courseService.getAllcourses();
+// }

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
-import { IDeactivateComponent } from '../Services/authguard.service';
+// import { IDeactivateComponent } from '../Services/authguard.service';
 
 @Component({
   selector: 'app-contact',
   templateUrl: './contact.component.html',
   styleUrls: ['./contact.component.css']
 })
-export class ContactComponent implements IDeactivateComponent {
+// export class ContactComponent implements IDeactivateComponent {
+  export class ContactComponent {
   firstName: string = '';
   lastName: string = '';
   country: string = 'usa';

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -31,7 +31,7 @@
                     <div class="course-rating"><b>RATINGS:</b> {{ course.rating }}</div>
                 </div>
                 <div class="course-action-buttons">
-                    <button class="btn" >BUY NOW</button>
+                    <button class="btn" routerLink="/Courses/Checkout">BUY NOW</button>
                     <!-- use relative path like from Course which will append to current ..Courses/Course/id-->
                     <button class="btn" [routerLink]="'Course/' + course.id" >DETAILS</button>
                      <!-- Absolute path below that appends on base url like ..4200:/Courses/Course/id-->

--- a/src/app/home/popular-list/popular/popular.component.html
+++ b/src/app/home/popular-list/popular/popular.component.html
@@ -13,7 +13,7 @@
         <div class="course-rating"><b>RATINGS:</b> {{ popular.rating }}</div>
     </div>
     <div class="course-action-buttons">
-        <button class="btn">BUY NOW</button>
+        <button class="btn" routerLink="/Courses/Checkout">BUY NOW</button>
         <button class="btn" [routerLink]="'/Home/Courses/Course/'+popular.id" >DETAILS</button>
     </div>
 </div>

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -12,7 +12,7 @@
             <label for="psw"><b>Password</b></label>
             <input type="password" placeholder="Enter Password" required #password>
               
-            <button type="submit" (click)="OnLoginClicked()">Login</button>
+            <button type="submit" (click)="logIn()">Login</button>
             <label>
               <input type="checkbox" checked="checked" name="remember"> Remember me
             </label>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,42 +1,69 @@
-import { Component, ElementRef, ViewChild, inject } from '@angular/core';
-import { AuthService } from '../Services/auth.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, ElementRef, OnInit, ViewChild, inject } from "@angular/core";
+import { AuthService } from "../Services/auth.service";
+import { ActivatedRoute, Router } from "@angular/router";
 
 @Component({
-  selector: 'app-login',
-  templateUrl: './login.component.html',
-  styleUrls: ['./login.component.css']
+  selector: "app-login",
+  templateUrl: "./login.component.html",
+  styleUrls: ["./login.component.css"],
 })
-export class LoginComponent {
-  @ViewChild('username') username: ElementRef;
-  @ViewChild('password') password: ElementRef;
+export class LoginComponent implements OnInit {
+  @ViewChild("username") username: ElementRef;
+  @ViewChild("password") password: ElementRef;
 
   authService: AuthService = inject(AuthService);
   router: Router = inject(Router);
   activeRoute: ActivatedRoute = inject(ActivatedRoute);
 
-  ngOnInit(){
-    this.activeRoute.queryParamMap.subscribe((queries) => {
-      const logout = Boolean(queries.get('logout'));
-      if(logout){
-        this.authService.logout();
-        alert('You are now logged out. IsLogged = ' + this.authService.isLogged);
-      }
+  ngOnInit(): void {
+    this.activeRoute.queryParamMap.subscribe((query) => {
+      const logout = Boolean(query.get('logout'));
+      if(logout) this.authService.logout();
+      // alert(`Is logged in = ${String(this.authService.authenticated())}`)
     })
   }
 
-  OnLoginClicked(){
-    const username = this.username.nativeElement.value;
+
+  logIn() {
+    const userName = this.username.nativeElement.value;
     const password = this.password.nativeElement.value;
-
-    const user = this.authService.login(username, password);
-
-    if(user === undefined){
-      alert('The login credentials you have entered is not correct.')
-    }
-    else{
-      alert('Welcome ' + user.name + '. You are logged in.');
-      this.router.navigate(['\Courses']);
+    const user = this.authService.login(userName, password);
+    if(user){
+      // alert(`Welcome ${user.name}! You are logged in`);
+      this.router.navigate(['/Home']);
+    }else{
+      this.username.nativeElement.value = '';
+      this.password.nativeElement.value = '';  
+      alert('Incorrect login credentials');
     }
   }
+
+
+
+
+
+  // ngOnInit(){
+  //   this.activeRoute.queryParamMap.subscribe((queries) => {
+  //     const logout = Boolean(queries.get('logout'));
+  //     if(logout){
+  //       this.authService.logout();
+  //       alert('You are now logged out. IsLogged = ' + this.authService.isLogged);
+  //     }
+  //   })
+  // }
+
+  // OnLoginClicked(){
+  //   const username = this.username.nativeElement.value;
+  //   const password = this.password.nativeElement.value;
+
+  //   const user = this.authService.login(username, password);
+
+  //   if(user === undefined){
+  //     alert('The login credentials you have entered is not correct.')
+  //   }
+  //   else{
+  //     alert('Welcome ' + user.name + '. You are logged in.');
+  //     this.router.navigate(['\Courses']);
+  //   }
+  // }
 }

--- a/src/app/routing.module.ts
+++ b/src/app/routing.module.ts
@@ -9,10 +9,10 @@ import { CourseDetailComponent } from "./courses/course-detail/course-detail.com
 import { NotFoundComponent } from "./not-found/not-found.component";
 import { LoginComponent } from "./login/login.component";
 import { CheckoutComponent } from "./checkout/checkout.component";
-import { AuthGuardService } from "./Services/authguard.service";
-import { CanActivate, CanActivateChild, resolve } from "./auth.guard";
+// import { CanActivate, CanActivateChild, resolve } from "./auth.guard";
 import { ServicesComponent } from "./home/services/services.component";
 import { PopularListComponent } from "./home/popular-list/popular-list.component";
+import { AuthGuardService } from "./Services/authguard.service";
 
 //DEFINE ROUTE
 const routes: Routes = [
@@ -25,7 +25,8 @@ const routes: Routes = [
   // { path : 'Courses/Course/:id', component: CourseDetailComponent}, //below is another way i.e using child route 
   { path: 'Courses', children: [
     { path: 'Course/:id', component: CourseDetailComponent},
-    { path: 'Popular', component: PopularListComponent}
+    { path: 'Popular', component: PopularListComponent},
+    { path: 'Checkout', component: CheckoutComponent, canActivate: [AuthGuardService]}
   ]},
   { path : 'Home/Courses/Course/:id', component: CourseDetailComponent},
   // { path : 'Courses/Course/:id/:name'},
@@ -53,12 +54,15 @@ const routes: Routes = [
   //     { path: "checkout", component: CheckoutComponent },
   //   ],
   // },
-  { path: "Login", component: LoginComponent },
+  { path: 'Login', component: LoginComponent},
   { path: "**", component: NotFoundComponent },
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, {
+    scrollPositionRestoration: 'enabled',
+    anchorScrolling: 'enabled',
+  })],
   exports: [RouterModule],
 })
 export class RoutingModule {}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,11 @@
     padding: 0px;
     box-sizing: border-box;
 }
+
+html {
+scroll-behavior: smooth;
+}
+  
 body{
     font-family: 'Poppins', sans-serif;
     background-color: #FBFCFC;


### PR DESCRIPTION
Implemented old auth guard canActivate route. In AuthGuardService, canAactivate is an interface method that uses modifier -  'implements' and the method returns boolean value (or Observable<boolean > or Promise<boolean> ex by calling a method of auth service returning login status). This is depricated in angular 14+ 